### PR TITLE
issue-586: fix missing '/' in the studyURL (related refactoring)

### DIFF
--- a/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisResultStatusDTO.java
+++ b/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisResultStatusDTO.java
@@ -42,4 +42,8 @@ public enum  CommonAnalysisResultStatusDTO {
 
         return title;
     }
+
+    public String getTitle() {
+        return title;
+    }
 }


### PR DESCRIPTION
Within the mentioned issue I noticed incorrect usage of the toString method for accessing enum title value, first we need to expose getTitle method and after migrate the code to use it