### PR TITLE
adds filename sanitize utils

### DIFF
--- a/arachne-common-utils/src/main/java/com/odysseusinc/arachne/commons/utils/CommonFilenameUtils.java
+++ b/arachne-common-utils/src/main/java/com/odysseusinc/arachne/commons/utils/CommonFilenameUtils.java
@@ -1,0 +1,35 @@
+package com.odysseusinc.arachne.commons.utils;
+
+import java.util.Objects;
+
+public class CommonFilenameUtils {
+
+    private static final String POSIX_RESERVED_CHARS = "[/\u0000]";
+    private static final String WIN_ILLEGAL_CHARS = "[<>:\"/\\\\|?*\\u0000]";
+
+    private CommonFilenameUtils() {}
+
+    /**
+     * Strict sanitization of given filename both valid for Windows and *nix systems.
+     * <p></p>Filters most of characters enumerated by the Microsoft's
+     * <a href="https://docs.microsoft.com/ru-ru/windows/win32/fileio/naming-a-file">Naming conventions</a>
+     * </p>
+     * @param filename
+     * @return
+     */
+    public static String sanitizeFilename(String filename) {
+
+        return Objects.requireNonNull(filename).replaceAll(WIN_ILLEGAL_CHARS,"");
+    }
+
+    /**
+     * Sanitize filename according to POSIX filename limitations.
+     * Reserved symbols are / and null
+     * @param filename
+     * @return
+     */
+    public static String sanitizeFilenamePosix(String filename) {
+
+        return Objects.requireNonNull(filename).replaceAll(POSIX_RESERVED_CHARS, "");
+    }
+}

--- a/arachne-common-utils/src/test/java/com/odysseusinc/arachne/commons/utils/CommonFilenameUtilsTest.java
+++ b/arachne-common-utils/src/test/java/com/odysseusinc/arachne/commons/utils/CommonFilenameUtilsTest.java
@@ -1,0 +1,26 @@
+package com.odysseusinc.arachne.commons.utils;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+public class CommonFilenameUtilsTest {
+
+    private static final String testFilename = "filename?\"containing\"/illegal<:>ch\\ars:)";
+    private static final String expectFilename = "filenamecontainingillegalchars)";
+    private static final String posixTestFilename = "another:name|to/test";
+    private static final String posixExpectName = "another:name|totest";
+
+    @Test
+    public void sanitizeFilename() {
+
+        String strictName = CommonFilenameUtils.sanitizeFilename(testFilename);
+        assertThat(strictName, is(equalTo(expectFilename)));
+
+        String posixName = CommonFilenameUtils.sanitizeFilenamePosix(posixTestFilename);
+        assertThat(posixName, is(equalTo(posixExpectName)));
+    }
+}


### PR DESCRIPTION
Resolves OHDSI/ArachneCentralAPI#624

The `sanitizeFilename` is actually to be used but the `sanitizeFilenamePosix` is reserved for future potential usage.
