### PR TITLE
ARACHNE-2767 -500 error code during authorization with empty credentials

### DIFF
--- a/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAuthenticationRequest.java
+++ b/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAuthenticationRequest.java
@@ -23,9 +23,13 @@
 package com.odysseusinc.arachne.commons.api.v1.dto;
 
 
+import org.hibernate.validator.constraints.NotBlank;
+
 public class CommonAuthenticationRequest {
 
+	@NotBlank(message = "Username cannot be empty")
 	private String username;
+	@NotBlank(message = "Password cannot be empty")
 	private String password;
 
 	public CommonAuthenticationRequest() {


### PR DESCRIPTION
fixes: ARACHNE-2767 500 error code during authorization with empty credentials
- add validation annotations