### PR TITLE
flyway migration does not work on the empty db.

### DIFF
--- a/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/config/flyway/ApplicationContextAwareSpringJdbcMigrationExecutor.java
+++ b/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/config/flyway/ApplicationContextAwareSpringJdbcMigrationExecutor.java
@@ -23,28 +23,33 @@ package com.odysseusinc.arachne.commons.config.flyway;
 import java.sql.Connection;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.resolver.MigrationExecutor;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Adapter for executing migrations implementing ApplicationContextAwareSpringMigration.
  */
 public class ApplicationContextAwareSpringJdbcMigrationExecutor implements MigrationExecutor {
-    /**
-     * The ApplicationContextAwareSpringMigration to execute.
-     */
-    private final ApplicationContextAwareSpringMigration springJdbcMigration;
+
+    private final ApplicationContext applicationContext;
+
+    private final String className;
 
     /**
      * Creates a new ApplicationContextAwareSpringMigration.
      *
      * @param springJdbcMigration The Application Context Aware Spring Jdbc Migration to execute.
+     * @param applicationContext
      */
-    public ApplicationContextAwareSpringJdbcMigrationExecutor(ApplicationContextAwareSpringMigration springJdbcMigration) {
-        this.springJdbcMigration = springJdbcMigration;
+    public ApplicationContextAwareSpringJdbcMigrationExecutor(ApplicationContext applicationContext, String className) {
+
+        this.applicationContext = applicationContext;
+        this.className = className;
     }
 
     @Override
     public void execute(Connection connection) {
         try {
+            ApplicationContextAwareSpringMigration springJdbcMigration = (ApplicationContextAwareSpringMigration)applicationContext.getBean(className);
             springJdbcMigration.migrate();
         } catch (Exception e) {
             throw new FlywayException("Migration failed !", e);


### PR DESCRIPTION
flyway migration does not work on the empty db.
explanation:
spring-flyway scripts loaded spring-context during initialization step, so the table was not created and this was a cause of the exception.  Now spring-context loaded right before execution