### PR TITLE
fix for: unknown name value [REPORTING] for enum class

### DIFF
--- a/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
+++ b/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
@@ -33,6 +33,7 @@ public enum CommonAnalysisType {
     COHORT_PATHWAY("Cohort Pathway", "txp"),
 
     //Reporting is currently unsupported. REPORTING value are used for compatibility with old existing analyzes
+    @Deprecated
     REPORTING("Reporting", "rep");
 
     private String title;

--- a/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
+++ b/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
@@ -32,7 +32,9 @@ public enum CommonAnalysisType {
     INCIDENCE("Incidence rates", "ir"),
     COHORT_PATHWAY("Cohort Pathway", "txp"),
 
-    //Reporting is currently unsupported. REPORTING value are used for compatibility with old existing analyzes
+    /**
+     * REPORTING is currently unsupported. This left for backward compatibility only.
+     */
     @Deprecated
     REPORTING("Reporting", "rep");
 

--- a/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
+++ b/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
@@ -30,7 +30,10 @@ public enum CommonAnalysisType {
     COHORT_HERACLES("Cohort (Heracles)", "cc_hrcls"),
     COHORT("Cohort (Simple Counts)", "c"),
     INCIDENCE("Incidence rates", "ir"),
-    COHORT_PATHWAY("Cohort Pathway", "txp");
+    COHORT_PATHWAY("Cohort Pathway", "txp"),
+
+    //Reporting is currently unsupported. REPORTING value are used for compatibility with old existing analyzes
+    REPORTING("Reporting", "rep");
 
     private String title;
 


### PR DESCRIPTION
fix for: unknown name value [REPORTING] for enum class
REPORTING type is necessary for support old existed analyzes.
So we return it back