### PR TITLE
fix for: unknown name value [REPORTING] for enum class (#235)

### DIFF
--- a/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
+++ b/arachne-commons/src/main/java/com/odysseusinc/arachne/commons/api/v1/dto/CommonAnalysisType.java
@@ -30,7 +30,13 @@ public enum CommonAnalysisType {
     COHORT_HERACLES("Cohort (Heracles)", "cc_hrcls"),
     COHORT("Cohort (Simple Counts)", "c"),
     INCIDENCE("Incidence rates", "ir"),
-    COHORT_PATHWAY("Cohort Pathway", "txp");
+    COHORT_PATHWAY("Cohort Pathway", "txp"),
+
+    /**
+     * REPORTING is currently unsupported. This left for backward compatibility only.
+     */
+    @Deprecated
+    REPORTING("Reporting", "rep");
 
     private String title;
 


### PR DESCRIPTION
* fix for: unknown name value [REPORTING] for enum class
REPORTING type is necessary for support old existed analyzes.
So we return it back

* fix for: unknown name value [REPORTING] for enum class
add Deprecated to the CommonAnalysisType.REPORING

* fix for: unknown name value [REPORTING] for enum class
add jdoc for Reporting type

(cherry picked from commit 7f8b48d1610c2b2d0a961bd5ccf2b3bf3c0d7c8e)