### PR TITLE
Initial support for InterSystems IRIS (1.17.x)

### DIFF
--- a/arachne-common-types/src/main/java/com/odysseusinc/arachne/commons/types/DBMSType.java
+++ b/arachne-common-types/src/main/java/com/odysseusinc/arachne/commons/types/DBMSType.java
@@ -35,7 +35,8 @@ public enum DBMSType {
     HIVE("Apache Hive", "hive"),
     SPARK("Spark", "spark"),
     SNOWFLAKE("Snowflake", "snowflake"),
-    SYNAPSE("Azure Synapse", "synapse");
+    SYNAPSE("Azure Synapse", "synapse"),
+    IRIS("InterSystems IRIS", "iris");
 
     private String label;
     // For further pass into SqlRender.translateSql as "targetDialect" and DatabaseConnector as "dbms"

--- a/execution-engine-commons/src/main/java/com/odysseusinc/arachne/execution_engine_common/util/ConnectionParamsParser.java
+++ b/execution-engine-commons/src/main/java/com/odysseusinc/arachne/execution_engine_common/util/ConnectionParamsParser.java
@@ -29,6 +29,7 @@ public final class ConnectionParamsParser {
             case SYNAPSE:
             case PDW:
             case SNOWFLAKE:
+            case IRIS:
                 return new GenericParser();
             case REDSHIFT:
                 return new RedshiftParser();


### PR DESCRIPTION
This PR is to include InterSystems IRIS to the list of supported dbms types, complementing the recent inclusion in https://github.com/OHDSI/SqlRender/pull/377 and ahead of further PRs to repositories that depend on ArachneCommons (namely OHDSI/WebAPI).

This complements the change to the main develop branch in #324 , hoping it makes it easier to get an ArachneCommons release that OHDSI/WebAPI can consume, per @alex-odysseus suggestion